### PR TITLE
chore: add templates and workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: File a bug report
+title: "[Bug]: "
+labels:
+  - bug
+assignees:
+---
+
+# **🐞 Bug Report**
+
+## Description
+
+_Describe the problem you are having. Provide as much detail as possible._
+
+## Regression Result
+
+* **Last working version:** 0.0.1
+
+## Replication
+
+1. _Replication steps here..._
+
+## Expected
+
+_Describe what the program should have been doing._
+
+## Solution
+
+_Describe the possible solution to the problem._
+
+## Media
+
+_Attach any media that can help describe the issue. This is optional._
+
+## Environment
+
+* **Operating System:** MacOS 13.4 (22F66) Ventura
+* **Machine:** Apple M1 Max, 32GB RAM
+* **Rust:** 1.7.0
+
+## Additional Context
+
+_Any other information regarding this issue._

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Developer contact
+    email: zana.github@icloud.com
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Add new advancement
+title: "[Feature]: "
+labels:
+  - enhancement
+assignees:
+---
+
+# 🚀 Feature Request
+
+## Description
+
+_Describe what is the feature you are requesting._
+
+## Reason
+
+_Why do we need this new feature?_
+
+## Solution
+
+_Describe the best solution out of possible other solutions._
+
+## Alternative Solutions
+
+_Describe any other solutions to be considered in case the main one above is difficult to produce._
+
+## Additional Context
+
+_Any other information regarding this issue._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+# Pull Request template
+
+## Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
+any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please select the options that are relevant.
+
+- [ ] **feature:** (new feature for the user, not a new feature for build script)
+- [ ] **fix:** (bug fix for the user, not a fix to a build script)
+- [ ] **docs:** (changes to the documentation)
+- [ ] **refactor:** (refactoring production code, e.g. renaming a variable)
+- [ ] **test:** (adding missing tests, refactoring tests; no production code change)
+- [ ] **chore:** (updating grunt tasks etc.; no production code change)
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
+list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+
+* Firmware version:
+* Hardware:
+* Toolchain:
+* SDK:
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+env:
+  CARGO_TERM_COLOR: always
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build
+        run: cargo build --release --verbose
+
+      - name: Test
+        run: cargo test --all --verbose --no-fail-fast --release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+# Commits
+
+Creating new commits should have descriptive names. Please use one of the following prefixes followed by the message.
+
+* **feature:** (new feature for the user, not a new feature for build script)
+* **fix:** (bug fix for the user, not a fix to a build script)
+* **docs:** (changes to the documentation)
+* **refactor:** (refactoring production code, eg. renaming a variable)
+* **test:** (adding missing tests, refactoring tests; no production code change)
+* **chore:** (updating grunt tasks etc; no production code change)
+
+## Pull Request Process
+
+Please see the [pull request template](./.github/pull_request_template.md).
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+
+[version]: http://contributor-covenant.org/version/1/4/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2023 Neon
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
squashed commits:

chore: add config for issue templates
chore: rename issue templates
chore: add frontmatter for issue templates
refactor: change workflow frontmatter to use about 
chore: add ci build
chore: add MIT License
chore: add contributing document and PR template