### PR TITLE
feat: create list parser

### DIFF
--- a/src/core/parser/bool/mod.rs
+++ b/src/core/parser/bool/mod.rs
@@ -6,8 +6,9 @@ use nom::branch::alt;
 
 use crate::core::parser::bool::pfalse::*;
 use crate::core::parser::bool::ptrue::*;
-use crate::core::parser::bool::structure::*;
 use crate::core::parser::prelude::*;
+
+pub use crate::core::parser::bool::structure::Bool;
 
 pub fn bool(input: &str) -> Result<&str, Bool> {
     alt((ptrue, pfalse))(input)

--- a/src/core/parser/list/mod.rs
+++ b/src/core/parser/list/mod.rs
@@ -1,0 +1,124 @@
+mod structure;
+
+use nom::bytes::complete::tag;
+use nom::character::complete::multispace0;
+use nom::combinator::all_consuming;
+use nom::multi::separated_list0;
+use nom::sequence::delimited;
+
+pub use crate::core::parser::list::structure::List;
+
+use crate::core::parser::bool::*;
+use crate::core::parser::prelude::Result;
+
+fn items(input: &str) -> Result<&str, Vec<Bool>> {
+    separated_list0(delimited(multispace0, tag(","), multispace0), bool)(input)
+}
+
+pub fn list(input: &str) -> Result<&str, List> {
+    all_consuming(delimited(
+        tag("["),
+        delimited(multispace0, items, multispace0),
+        tag("]"),
+    ))(input)
+    .map(|(remaining, values)| (remaining, List { values }))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::core::parser::bool::Bool;
+    use crate::core::parser::list::*;
+
+    #[test]
+    fn empty() {
+        let expected = Ok(("", List { values: vec![] }));
+        let actual = list("[]");
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn single() {
+        let expected = Ok((
+            "",
+            List {
+                values: vec![Bool::True],
+            },
+        ));
+        let actual = list("[true]");
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn multi() {
+        let expected = Ok((
+            "",
+            List {
+                values: vec![Bool::True, Bool::False],
+            },
+        ));
+        let actual = list("[true,false]");
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn empty_with_padding() {
+        let expected = Ok(("", List { values: vec![] }));
+        let actual = list("[ ]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[\n]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[\t]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[\n\n]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[\t\t]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[ \n\t]");
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn single_with_padding() {
+        let expected = Ok((
+            "",
+            List {
+                values: vec![Bool::True],
+            },
+        ));
+        let actual = list("[ true ]");
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn multi_with_padding() {
+        let expected = Ok((
+            "",
+            List {
+                values: vec![Bool::True, Bool::False],
+            },
+        ));
+        let actual = list("[ true,false ]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[ true ,false ]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[ true, false ]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[ true , false ]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[ true\t,\tfalse ]");
+        assert_eq!(expected, actual);
+
+        let actual = list("[ true\n,\nfalse ]");
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/core/parser/list/structure.rs
+++ b/src/core/parser/list/structure.rs
@@ -1,0 +1,6 @@
+use crate::core::parser::bool::Bool;
+
+#[derive(Debug, PartialEq)]
+pub struct List {
+    pub values: Vec<Bool>,
+}

--- a/src/core/parser/mod.rs
+++ b/src/core/parser/mod.rs
@@ -1,3 +1,4 @@
 pub mod bool;
 pub mod identifier;
+pub mod list;
 pub mod prelude;


### PR DESCRIPTION
# Pull Request template

## Description

Adds a list parser. It also takes in account padding.

Fixes #7 

# How Has This Been Tested?

I have created some unit tests for parsing:

- [x] An empty list
- [x] A list with 1 item
- [x] A list with multiple items
- [x] All the above with padding including between elements.
