### PR TITLE
feat: add block parser as per #18

### DIFF
--- a/src/core/parser/block.rs
+++ b/src/core/parser/block.rs
@@ -1,0 +1,91 @@
+use nom::{combinator::opt, multi::many1, sequence::delimited, IResult};
+
+use super::{
+    brace::{left_brace, right_brace},
+    expression::{expression, Expression},
+    padded::padded0,
+};
+
+#[derive(Debug, PartialEq)]
+pub struct Block {
+    body: Option<Vec<Expression>>,
+}
+
+pub fn block(input: &str) -> IResult<&str, Block> {
+    delimited(
+        left_brace,
+        padded0(opt(many1(padded0(expression)))),
+        right_brace,
+    )(input)
+    .map(|(remaining, result)| (remaining, Block { body: result }))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::core::parser::boolean::Boolean;
+
+    use super::*;
+
+    #[test]
+    fn empty_block() {
+        let expected = Ok(("", Block { body: None }));
+
+        let result = block("{}");
+        assert_eq!(expected, result);
+
+        let result = block("{   }");
+        assert_eq!(expected, result);
+
+        let result = block("{\t\t\t}");
+        assert_eq!(expected, result);
+
+        let result = block("{\n\n\n}");
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn single_expression_block() {
+        let expected = Ok((
+            "",
+            Block {
+                body: Some(vec![Expression::Boolean(Boolean::True)]),
+            },
+        ));
+
+        let result = block("{true;}");
+        assert_eq!(expected, result);
+
+        let result = block("{   true;   }");
+        assert_eq!(expected, result);
+
+        let result = block("{\t\t\ttrue;\t\t\t}");
+        assert_eq!(expected, result);
+
+        let result = block("{\n\n\ntrue;\n\n\n}");
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn multi_expression_block() {
+        let expected = Ok((
+            "",
+            Block {
+                body: Some(vec![
+                    Expression::Boolean(Boolean::True),
+                    Expression::Boolean(Boolean::False),
+                    Expression::Boolean(Boolean::True),
+                ]),
+            },
+        ));
+
+        let result = block("{true;false;true;}");
+        assert_eq!(expected, result);
+
+        let result = block("{true;   false;   true;}");
+        assert_eq!(expected, result);
+
+        let result = block("{true;\t\t\tfalse;\t\t\ttrue;}");
+        assert_eq!(expected, result);
+    }
+}

--- a/src/core/parser/boolean.rs
+++ b/src/core/parser/boolean.rs
@@ -1,20 +1,20 @@
 use nom::{branch::alt, bytes::complete::tag, IResult};
 
 #[derive(PartialEq, Debug)]
-pub enum Bool {
+pub enum Boolean {
     True,
     False,
 }
 
-fn t(input: &str) -> IResult<&str, Bool> {
-    tag("true")(input).map(|(remaining, _)| (remaining, Bool::True))
+fn t(input: &str) -> IResult<&str, Boolean> {
+    tag("true")(input).map(|(remaining, _)| (remaining, Boolean::True))
 }
 
-fn f(input: &str) -> IResult<&str, Bool> {
-    tag("false")(input).map(|(remaining, _)| (remaining, Bool::False))
+fn f(input: &str) -> IResult<&str, Boolean> {
+    tag("false")(input).map(|(remaining, _)| (remaining, Boolean::False))
 }
 
-pub fn boolean(input: &str) -> IResult<&str, Bool> {
+pub fn boolean(input: &str) -> IResult<&str, Boolean> {
     alt((t, f))(input)
 }
 
@@ -25,14 +25,14 @@ mod tests {
 
     #[test]
     fn t() {
-        let expected = Ok(("", Bool::True));
+        let expected = Ok(("", Boolean::True));
         let actual = boolean("true");
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn f() {
-        let expected = Ok(("", Bool::False));
+        let expected = Ok(("", Boolean::False));
         let actual = boolean("false");
         assert_eq!(expected, actual);
     }

--- a/src/core/parser/brace.rs
+++ b/src/core/parser/brace.rs
@@ -1,0 +1,9 @@
+use nom::{character::complete::char, IResult};
+
+pub fn left_brace(input: &str) -> IResult<&str, char> {
+    char('{')(input)
+}
+
+pub fn right_brace(input: &str) -> IResult<&str, char> {
+    char('}')(input)
+}

--- a/src/core/parser/expression.rs
+++ b/src/core/parser/expression.rs
@@ -1,0 +1,52 @@
+use nom::{
+    character::complete::multispace0,
+    sequence::{preceded, terminated},
+    IResult,
+};
+
+use super::{
+    boolean::{boolean, Boolean},
+    semi_colon::semi_colon,
+};
+
+#[derive(Debug, PartialEq)]
+pub enum Expression {
+    Boolean(Boolean),
+}
+
+pub fn expression(input: &str) -> IResult<&str, Expression> {
+    terminated(boolean, preceded(multispace0, semi_colon))(input)
+        .map(|(remaining, result)| (remaining, Expression::Boolean(result)))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn boolean_expression_zero_space() {
+        let expected = Ok(("", Expression::Boolean(Boolean::True)));
+        let result = expression("true;");
+        assert_eq!(expected, result);
+
+        let expected = Ok(("", Expression::Boolean(Boolean::False)));
+        let result = expression("false;");
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn boolean_expression_many_space() {
+        let expected = Ok(("", Expression::Boolean(Boolean::True)));
+        let result = expression("true   ;");
+        assert_eq!(expected, result);
+
+        let expected = Ok(("", Expression::Boolean(Boolean::True)));
+        let result = expression("true\n\n\n;");
+        assert_eq!(expected, result);
+
+        let expected = Ok(("", Expression::Boolean(Boolean::True)));
+        let result = expression("true\t\t\t;");
+        assert_eq!(expected, result);
+    }
+}

--- a/src/core/parser/mod.rs
+++ b/src/core/parser/mod.rs
@@ -1,6 +1,11 @@
 pub mod alpha;
+pub mod block;
 pub mod boolean;
+pub mod brace;
 pub mod equals;
+pub mod expression;
 pub mod identifier;
 pub mod numeric;
+pub mod padded;
+pub mod semi_colon;
 pub mod underscore;

--- a/src/core/parser/padded.rs
+++ b/src/core/parser/padded.rs
@@ -1,0 +1,24 @@
+use nom::{
+    character::complete::{multispace0, multispace1},
+    error::ParseError,
+    sequence::delimited,
+    IResult, Parser,
+};
+
+pub fn padded0<'a, F, O, E: ParseError<&'a str>>(
+    inner: F,
+) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+where
+    F: Parser<&'a str, O, E>,
+{
+    delimited(multispace0, inner, multispace0)
+}
+
+pub fn padded1<'a, F, O, E: ParseError<&'a str>>(
+    inner: F,
+) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+where
+    F: Parser<&'a str, O, E>,
+{
+    delimited(multispace1, inner, multispace1)
+}

--- a/src/core/parser/semi_colon.rs
+++ b/src/core/parser/semi_colon.rs
@@ -1,0 +1,5 @@
+use nom::{character::complete::char, IResult};
+
+pub fn semi_colon(input: &str) -> IResult<&str, char> {
+    char(';')(input)
+}


### PR DESCRIPTION
# Pull Request template

## Description

Adds the block parser. At the moment it only accepts expressions but this will need to change so that it can also allow for statements.

Fixes #18
